### PR TITLE
1.x Permission System Upgrade & Username Email Address Enforcement

### DIFF
--- a/api/APIUtil.js
+++ b/api/APIUtil.js
@@ -1,16 +1,36 @@
-const ServerException = require("./ServerException");
 const DebugLog = require("./entities/DebugLog");
 
 module.exports = {
 
     hasPermission: function (user, permission){
+        const ServerException = require("./ServerException");
         if(user !== undefined){
             if(user.superuser){
                 return true;
             }
 
-            if(user.permissions.includes(permission)){
-                return true;
+            let split_permission = permission.split('.');
+
+            for(let x = 0; x < user.permissions.length; x++){
+                let granted_permission = user.permissions[x].split(".");
+                let passed_count = 0;
+                for(let i = 0; i < split_permission.length; i++){
+                    if(granted_permission.length >= i+1){
+                        let granted_node = granted_permission[i];
+                        let needed_node = split_permission[i];
+                        if(granted_node !== needed_node){
+                            if(granted_node === "*" && passed_count === i){
+                                return true;
+                            }
+                        }else{
+                            passed_count++;
+                        }
+                    }
+                }
+
+                if(passed_count === split_permission.length){
+                    return true;
+                }
             }
         }
         throw new ServerException(403, "permission_denied", "You lack sufficient permission to access this data");

--- a/api/endpoints/auth/has_access.js
+++ b/api/endpoints/auth/has_access.js
@@ -32,7 +32,9 @@ module.exports = function(req, res, next){
                 let granted = true;
 
                 for(let i = 0; i < route.permissions.length; i++){
-                    if(!user.permissions.includes(route.permissions[i])){
+                    try{
+                        APIUtil.hasPermission(user, route.permissions[i]);
+                    }catch (e){
                         granted = false;
                         break;
                     }

--- a/api/index.js
+++ b/api/index.js
@@ -2,8 +2,6 @@ const express = require("express");
 const bodyParser = require("body-parser");
 const ServerException = require("./ServerException");
 const config = require("../../../server.config");
-const fs = require("fs");
-const StaticUtil = require("./StaticUtil");
 const PluginEventDispatcher = require("./plugins/PluginEventDispatcher");
 const BoostPlugin = require("./plugins/BoostPlugin");
 
@@ -106,67 +104,7 @@ for(let i = 0; i < config.plugins.length; i++){
     }
 }
 
-{
-    let start_dirs = [];
-
-    let dir_1 = fs.readdirSync(__dirname);
-    let dir_2 = fs.readdirSync(__dirname + "/../../../api");
-
-    for(let i = 0; i < dir_1.length; i++){
-        start_dirs.push(__dirname + "/" + dir_1[i]);
-    }
-    for(let i = 0; i < dir_2.length; i++){
-        start_dirs.push(__dirname + "/../../../api/" + dir_2[i]);
-    }
-
-    let js_files = [];
-
-    let recursive_read = function(dir){
-        let dirs = fs.readdirSync(dir);
-        for(let i = 0; i < dirs.length; i++){
-            let ndir = dir + "/" + dirs[i];
-            if(fs.lstatSync(ndir).isDirectory()){
-                recursive_read(ndir);
-            }else if(fs.lstatSync(ndir).isFile() && ndir.endsWith(".js")) {
-                js_files.push(ndir);
-            }
-        }
-    }
-
-    for(let i = 0; i < start_dirs.length; i++){
-        let dir = start_dirs[i];
-        if(fs.lstatSync(dir).isDirectory()){
-            recursive_read(dir);
-        }else if(fs.lstatSync(dir).isFile() && dir.endsWith(".js")){
-            js_files.push(dir);
-        }
-    }
-
-    const exclude_list = [
-        __dirname + "/APIUtil.js",
-        __dirname + "/index.js",
-        __dirname + "/sanitizer.js",
-        __dirname + "/ServerException.js"
-    ]
-
-    let permissions = [];
-
-    for(let i = 0; i < js_files.length; i++){
-        let js_file = js_files[i];
-        if(!exclude_list.includes(js_file)){
-            let data = fs.readFileSync(js_file, {encoding:'utf8', flag:'r'});
-            let match_result = data.match(/APIUtil.hasPermission\(.+,.*("|')(.*)("|')/);
-            if(match_result !== null && match_result.length > 3){
-                let permission = match_result[2];
-                if(!permissions.includes(permission)){
-                    permissions.push(permission);
-                }
-            }
-        }
-    }
-
-    StaticUtil.permissions = permissions;
-}
+PluginEventDispatcher.onStart();
 
 module.exports = {
     path: '/api',

--- a/api/plugins/BoostPlugin.js
+++ b/api/plugins/BoostPlugin.js
@@ -1,5 +1,9 @@
 class BoostPlugin {
 
+    onStart(){
+        return null;
+    }
+
     onExceptionCaught(error, status, description, uuid, currentStack){
         return null;
     }

--- a/api/plugins/PluginEventDispatcher.js
+++ b/api/plugins/PluginEventDispatcher.js
@@ -2,6 +2,12 @@ class PluginEventDispatcher {
 
     static plugins = [];
 
+    static onStart(){
+        for(let i = 0; i < this.plugins.length; i++){
+            this.plugins[i].onStart();
+        }
+    }
+
     static onExceptionCaught(error, status, description, uuid, currentStack){
         for(let i = 0; i < this.plugins.length; i++){
             this.plugins[i].onExceptionCaught(error, status, description, uuid, currentStack);

--- a/components/Login.vue
+++ b/components/Login.vue
@@ -1,0 +1,180 @@
+<template>
+    <div class="page-container">
+        <div class="background-container primary"></div>
+        <v-container class="fill-height">
+            <v-row align="center" justify="center" class="px-4">
+                <v-card width="550" min-height="300" elevation="6" :loading="form_loading" :disabled="form_loading">
+                    <v-tabs-items v-model="tab">
+                        <v-tab-item>
+                            <v-row justify="center" class="pt-4">
+                                <slot name="logo">
+                                    <v-card-title>
+                                        <v-avatar size="48" tile>
+                                            <svg :style="style" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 175.53 175.53"><path d="M172.33,64.27a87.82,87.82,0,0,1-36,96.59q-2.26,1.51-4.67,2.9a87.65,87.65,0,0,1-21.17,8.79,86.43,86.43,0,0,1-23.5,3,87.39,87.39,0,0,1-16.56-1.74q-2.7-.54-5.36-1.26a87.52,87.52,0,0,1-20.47-8.36l-.7-.39a86.66,86.66,0,0,1-18.17-13.94l-.58-.57a88,88,0,0,1-13.36-17.62q-1.38-2.4-2.6-4.85a87.74,87.74,0,0,1,30-112.12q2.28-1.51,4.68-2.9a87.41,87.41,0,0,1,61.24-10q2.7.54,5.35,1.25A87.37,87.37,0,0,1,131,11.37l-.26,1L125,33.49a65.91,65.91,0,0,0-16.72-8.25c-1.16-.38-2.32-.73-3.5-1A65.62,65.62,0,0,0,58.07,29l0-.14-3.25,1.88a65.57,65.57,0,0,0-30.66,40l-1,3.63.13-.07a65.61,65.61,0,0,0,7.42,46.38c.61,1.06,1.26,2.1,1.92,3.11a65,65,0,0,0,12.29,14A63.85,63.85,0,0,0,50.51,142a65.78,65.78,0,0,0,16.72,8.26c1.16.38,2.32.72,3.5,1a66,66,0,0,0,22.16,2.06,65.21,65.21,0,0,0,24.55-6.89l0,.14,3.26-1.88a65.6,65.6,0,0,0,30.66-40l1-3.63L109.7,125.76a43.84,43.84,0,0,1-43.88,0,43.94,43.94,0,0,1-21.94-38,44.28,44.28,0,0,1,1.5-11.36A43.75,43.75,0,0,1,65.83,49.76a44.38,44.38,0,0,1,10.58-4.39A43.93,43.93,0,0,1,118.8,56.73l-4.17,15.52L87.77,87.76l5.67-21.19a21.94,21.94,0,1,0,5.29,40.19Z"/></svg>
+                                        </v-avatar>
+                                    </v-card-title>
+                                </slot>
+                            </v-row>
+                            <v-row justify="center">
+                                <slot name="heading">
+                                    <v-card-title class="pt-0" style="text-align: center; word-break: keep-all;">{{project_name}}</v-card-title>
+                                    <v-card-text style="text-align: center">Boost Management System<br/>v{{version}}</v-card-text>
+                                </slot>
+                            </v-row>
+                            <v-row justify="center" class="pt-4">
+                                <v-alert type="error" dense text dismissible class="mb-0" :value="error" v-model="error">
+                                    {{error_text}}
+                                </v-alert>
+                            </v-row>
+                            <v-row justify="center" class="pb-8">
+                                <v-form v-model="valid" class="px-12">
+                                    <v-container>
+                                        <v-row>
+                                            <v-col cols="12" md="12">
+                                                <v-text-field v-model="username" :rules="usernameRules" label="Email Address" required autofocus></v-text-field>
+                                            </v-col>
+                                            <v-col cols="12" md="12">
+                                                <v-text-field class="a-field" v-model="password" v-on:keyup="fieldEnterPress" :rules="passwordRules" label="Password" :type="password_show ? 'text' : 'password'" :append-icon="password_show ? 'mdi-eye' : 'mdi-eye-off'" @click:append="password_show = !password_show"></v-text-field>
+<!--                                                <v-card-text style="text-align: right;" class="pa-0 pt-2 text-body-2">-->
+<!--                                                    <a color="primary" @click="tab = 1">Forgot Password?</a>-->
+<!--                                                </v-card-text>-->
+                                            </v-col>
+                                        </v-row>
+                                        <v-row justify="center" class="mt-12">
+                                            <v-btn color="secondary" depressed class="px-8" @click="login(username, password)">Login</v-btn>
+                                        </v-row>
+                                    </v-container>
+                                </v-form>
+                            </v-row>
+                        </v-tab-item>
+                        <v-tab-item>
+                            <v-row justify="center" class="pt-8">
+                                <v-card-title style="text-align: center; word-break: keep-all;">Forgot Password?</v-card-title>
+                                <v-card-text style="text-align: center">Enter the username or email address associated with your account.</v-card-text>
+                            </v-row>
+                            <v-row justify="center" class="pt-4">
+                                <v-alert type="error" dense text dismissible class="mb-0" :value="error" v-model="error">
+                                    {{error_text}}
+                                </v-alert>
+                            </v-row>
+                            <v-row justify="center" class="pb-8">
+                                <v-form style="width: 100%;" class="px-12">
+                                    <v-container>
+                                        <v-row>
+                                            <v-col cols="12" md="12">
+                                                <v-text-field v-model="username" :rules="usernameRules" label="Username" required hide-details></v-text-field>
+                                            </v-col>
+                                        </v-row>
+                                        <v-row justify="center" class="mt-12">
+                                            <v-btn class="px-8 mx-4" depressed @click="tab = 0">Cancel</v-btn>
+                                            <v-btn color="secondary" class="px-8 mx-4" depressed>Next</v-btn>
+                                        </v-row>
+                                    </v-container>
+                                </v-form>
+                            </v-row>
+                        </v-tab-item>
+                        <v-tab-item>
+                            <v-row justify="center" align="center" style="min-height: 300px;">
+                                <v-progress-circular size="64" indeterminate color="grey lighten-1"></v-progress-circular>
+                            </v-row>
+                        </v-tab-item>
+                    </v-tabs-items>
+                </v-card>
+            </v-row>
+        </v-container>
+    </div>
+</template>
+
+<script>
+const axios = require("axios");
+import config from '../../../boost.config';
+export default {
+    name: "Login",
+    data(){
+        return {
+            tab: 0,
+            version: config.version,
+            project_name: config.projectName,
+            valid: false,
+            username: '',
+            password: '',
+            form_loading: false,
+            password_show: false,
+            error: false,
+            error_text: '',
+            usernameRules: [
+                v => !!v || 'Email Address is required',
+                value => {
+                    const pattern = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
+                    return pattern.test(value) || 'Invalid Email Address.'
+                }
+            ],
+            passwordRules: [
+                v => !!v || 'Password is required'
+            ]
+        }
+    },
+    methods: {
+        fieldEnterPress(e){
+            if(e.keyCode === 13){
+                this.login(this.username, this.password);
+            }
+        },
+        login: function(username, password){
+            if(username.length > 0 && password.length > 0){
+                let _this = this;
+                _this.form_loading = true;
+                axios.post("/api/auth/login", {
+                    username: username,
+                    password: password
+                }).then(function(response){
+                    _this.form_loading = false;
+                    _this.$router.push(response.data.direct_to);
+                }).catch(function(error, obj){
+                    _this.form_loading = false;
+                    if(!error.response){
+                        error.response = {
+                            status: 500
+                        };
+                    }
+                    switch(error.response.status){
+                        default:
+                        case 500:
+                            _this.error = true;
+                            _this.error_text = "Failed to connect to authentication server";
+                            break;
+                        case 400:
+                            _this.error = true;
+                            _this.error_text = "Invalid credentials";
+                            break;
+                    }
+                });
+            }
+        }
+    },
+    computed: {
+        style(){
+            if(!this.$vuetify.theme.dark){
+                return "fill: " + this.$vuetify.theme.defaults.light.primary;
+            }else{
+                return "fill: " + this.$vuetify.theme.defaults.dark.primary;
+            }
+        }
+    }
+}
+</script>
+
+<style scoped>
+    .page-container{
+        position: relative;
+        width: 100%;
+        height: 100%;
+    }
+    .background-container{
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: calc(50% - 100px);
+    }
+</style>

--- a/layouts/backend.vue
+++ b/layouts/backend.vue
@@ -35,7 +35,7 @@
 
         </v-navigation-drawer>
 
-        <v-app-bar app color="secondary" clipped-left dark :height="($vuetify.breakpoint.xsOnly) ? 50 : 60">
+        <v-app-bar app color="primary" clipped-left dark :height="($vuetify.breakpoint.xsOnly) ? 50 : 60">
             <v-app-bar-nav-icon @click.stop="toggle_nav"></v-app-bar-nav-icon>
 
             <v-toolbar-title>{{projectName}}</v-toolbar-title>

--- a/middleware/tsa.js
+++ b/middleware/tsa.js
@@ -41,14 +41,12 @@ const tsa = async function({app, route, store, redirect, error, env, req}){
                     store.commit('boost_store/setPermissions', user.permissions);
                     store.commit('boost_store/setSuperUser', user.superuser);
 
-                    if(!user.superuser){
-                        for(let i = 0; i < boost_route.permissions.length; i++){
-                            if(!user.permissions.includes(boost_route.permissions[i])){
-                                error({
-                                    statusCode: 403
-                                });
-                                return;
-                            }
+                    for(let i = 0; i < boost_route.permissions.length; i++){
+                        if(!store.getters['boost_store/hasPermission'](boost_route.permissions[i])){
+                            error({
+                                statusCode: 403
+                            });
+                            return;
                         }
                     }
                 }else{

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -43,6 +43,10 @@ let nuxt_config = {
 
         if(fs.existsSync(__dirname + "/../aspect")) {
             plugins.push(__dirname + "/../aspect/AspectPlugin");
+            plugins.push({
+                src: __dirname + "/../aspect/CKEditorPlugin",
+                mode: 'client'
+            });
         }
 
         return plugins;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "boost",
-    "version": "1.1.4",
+    "version": "1.1.5",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -411,6 +411,11 @@
             "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
             "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
             "optional": true
+        },
+        "nodemailer": {
+            "version": "6.4.17",
+            "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.4.17.tgz",
+            "integrity": "sha512-89ps+SBGpo0D4Bi5ZrxcrCiRFaMmkCt+gItMXQGzEtZVR3uAD3QAQIDoxTWnx3ky0Dwwy/dhFrQ+6NNGXpw/qQ=="
         },
         "npm": {
             "version": "6.14.9",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "express-session": "^1.17.1",
         "jsonwebtoken": "^8.5.1",
         "moment": "^2.29.0",
+        "nodemailer": "^6.4.17",
         "nuxt-session": "^1.0.3",
         "plasma": "github:epicdev-za/plasma",
         "restify-clients": "^2.6.9",

--- a/pages/admin/users/create.vue
+++ b/pages/admin/users/create.vue
@@ -8,7 +8,7 @@
                         <v-row>
 
                             <v-col cols="12" md="12" lg="7" class="py-0">
-                                <v-text-field label="Username" v-model="item.username" :rules="usernameRules" required autofocus></v-text-field>
+                                <v-text-field label="Email Address" v-model="item.username" :rules="usernameRules" required autofocus></v-text-field>
                             </v-col>
 
                             <v-col cols="12" md="12" lg="5" class="py-0">
@@ -123,7 +123,11 @@
             return {
                 valid: false,
                 usernameRules: [
-                    v => !!v || 'Username is required',
+                    v => !!v || 'Email Address is required',
+                    value => {
+                        const pattern = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
+                        return pattern.test(value) || 'Invalid Email Address.'
+                    }
                 ],
                 loading: false,
                 item: {

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -1,153 +1,16 @@
 <template>
-    <div class="page-container">
-        <div class="background-container primary"></div>
-        <v-container class="fill-height">
-            <v-row align="center" justify="center" class="px-4">
-                <v-card max-width="550" elevation="6" class="px-12" :loading="form_loading" :disabled="form_loading">
-                    <v-row justify="center" class="pt-4">
-                        <v-card-title>
-                            <v-avatar size="48" tile>
-                                <svg :style="style" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 175.53 175.53"><path d="M172.33,64.27a87.82,87.82,0,0,1-36,96.59q-2.26,1.51-4.67,2.9a87.65,87.65,0,0,1-21.17,8.79,86.43,86.43,0,0,1-23.5,3,87.39,87.39,0,0,1-16.56-1.74q-2.7-.54-5.36-1.26a87.52,87.52,0,0,1-20.47-8.36l-.7-.39a86.66,86.66,0,0,1-18.17-13.94l-.58-.57a88,88,0,0,1-13.36-17.62q-1.38-2.4-2.6-4.85a87.74,87.74,0,0,1,30-112.12q2.28-1.51,4.68-2.9a87.41,87.41,0,0,1,61.24-10q2.7.54,5.35,1.25A87.37,87.37,0,0,1,131,11.37l-.26,1L125,33.49a65.91,65.91,0,0,0-16.72-8.25c-1.16-.38-2.32-.73-3.5-1A65.62,65.62,0,0,0,58.07,29l0-.14-3.25,1.88a65.57,65.57,0,0,0-30.66,40l-1,3.63.13-.07a65.61,65.61,0,0,0,7.42,46.38c.61,1.06,1.26,2.1,1.92,3.11a65,65,0,0,0,12.29,14A63.85,63.85,0,0,0,50.51,142a65.78,65.78,0,0,0,16.72,8.26c1.16.38,2.32.72,3.5,1a66,66,0,0,0,22.16,2.06,65.21,65.21,0,0,0,24.55-6.89l0,.14,3.26-1.88a65.6,65.6,0,0,0,30.66-40l1-3.63L109.7,125.76a43.84,43.84,0,0,1-43.88,0,43.94,43.94,0,0,1-21.94-38,44.28,44.28,0,0,1,1.5-11.36A43.75,43.75,0,0,1,65.83,49.76a44.38,44.38,0,0,1,10.58-4.39A43.93,43.93,0,0,1,118.8,56.73l-4.17,15.52L87.77,87.76l5.67-21.19a21.94,21.94,0,1,0,5.29,40.19Z"/></svg>
-                            </v-avatar>
-                        </v-card-title>
-                    </v-row>
-                    <v-row justify="center">
-                        <v-card-title class="pt-0" style="text-align: center; word-break: keep-all;">{{project_name}}</v-card-title>
-                        <v-card-text style="text-align: center">Boost Management System<br/>v{{version}}</v-card-text>
-                    </v-row>
-                    <v-row justify="center" class="pt-4">
-                        <v-alert type="error" dense text dismissible class="mb-0" :value="error" v-model="error">
-                            {{error_text}}
-                        </v-alert>
-                    </v-row>
-                    <v-row justify="center" class="pb-4">
-                        <v-form v-model="valid">
-                            <v-container>
-                                <v-row>
-                                    <v-col cols="12" md="12">
-                                        <v-text-field v-model="username" :rules="usernameRules" label="Username" required autofocus></v-text-field>
-                                    </v-col>
-                                    <v-col cols="12" md="12">
-                                        <v-text-field class="a-field" v-model="password" v-on:keyup="fieldEnterPress" :rules="passwordRules" label="Password" :type="password_show ? 'text' : 'password'" :append-icon="password_show ? 'mdi-eye' : 'mdi-eye-off'" @click:append="password_show = !password_show"></v-text-field>
-                                    </v-col>
-                                </v-row>
-                                <v-row justify="center" class="mt-12">
-                                    <v-btn color="secondary" class="px-8" @click="login(username, password)">Login</v-btn>
-                                </v-row>
-                            </v-container>
-                        </v-form>
-                    </v-row>
-                </v-card>
-            </v-row>
-        </v-container>
-    </div>
+    <Login></Login>
 </template>
 
 <script>
-    const axios = require("axios");
-    import config from '../../../boost.config';
-    export default {
-        name: "login",
-        head(){
-            return {
-                title: "Login"
-            }
-        },
-        data(){
-            return {
-                version: config.version,
-                project_name: config.projectName,
-                valid: false,
-                username: '',
-                password: '',
-                form_loading: false,
-                password_show: false,
-                error: false,
-                error_text: '',
-                usernameRules: [
-                    v => !!v || 'Username is required',
-                ],
-                passwordRules: [
-                    v => !!v || 'Password is required'
-                ]
-            }
-        },
-        methods: {
-            fieldEnterPress(e){
-                if(e.keyCode === 13){
-                    this.login(this.username, this.password);
-                }
-            },
-            login: function(username, password){
-                if(username.length > 0 && password.length > 0){
-                    let _this = this;
-                    _this.form_loading = true;
-                    axios.post("/api/auth/login", {
-                        username: username,
-                        password: password
-                    }).then(function(response){
-                        _this.form_loading = false;
-                        _this.$router.push(response.data.direct_to);
-                    }).catch(function(error, obj){
-                        _this.form_loading = false;
-                        if(!error.response){
-                            error.response = {
-                                status: 500
-                            };
-                        }
-                        switch(error.response.status){
-                            default:
-                            case 500:
-                                _this.error = true;
-                                _this.error_text = "Failed to connect to authentication server";
-                                break;
-                            case 400:
-                                _this.error = true;
-                                _this.error_text = "Invalid credentials";
-                                break;
-                        }
-                    });
-                }
-            }
-        },
-        computed: {
-            style(){
-                if(!this.$vuetify.theme.dark){
-                    return "fill: " + this.$vuetify.theme.defaults.light.primary;
-                }else{
-                    return "fill: " + this.$vuetify.theme.defaults.dark.primary;
-                }
-            }
+import Login from '../components/Login';
+export default {
+    name: "login",
+    components: {Login},
+    head(){
+        return {
+            title: "Login"
         }
     }
+}
 </script>
-
-<style scoped>
-    .page-container{
-        position: relative;
-        width: 100%;
-        height: 100%;
-    }
-    .background-container{
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: calc(50% - 100px);
-    }
-</style>
-
-<style>
-    .login-bg .v-responsive__sizer{
-        position: absolute;
-    }
-    .login-bg .v-image__image{
-        top: 25%;
-        height: 50%;
-        box-shadow:inset 0 0 0 10000px rgba(0,114,186,0.8);
-        background-position: 50% bottom !important;
-    }
-    .a-field .v-input__icon--append i{
-        font-size: 20px;
-    }
-</style>

--- a/plugins/PermissionLoaderPlugin.js
+++ b/plugins/PermissionLoaderPlugin.js
@@ -1,0 +1,146 @@
+const BoostPlugin = require("../api/plugins/BoostPlugin");
+const fs = require("fs");
+const StaticUtil = require("./../api/StaticUtil");
+
+class PermissionLoaderPlugin extends BoostPlugin {
+
+    onStart() {
+        const permissions = [];
+
+        const backend_permissions = this.loadBackendPermissions();
+        for(let i = 0; i < backend_permissions.length; i++){
+            if(!permissions.includes(backend_permissions[i])){
+                permissions.push(backend_permissions[i]);
+            }
+        }
+
+        const frontend_permissions = this.loadFrontendPermissions();
+        for(let i = 0; i < frontend_permissions.length; i++){
+            if(!permissions.includes(frontend_permissions[i])){
+                permissions.push(frontend_permissions[i]);
+            }
+        }
+
+        StaticUtil.permissions = permissions;
+    }
+
+    loadBackendPermissions(){
+        let start_dirs = [];
+
+        let dir_1 = fs.readdirSync(__dirname + "/../api");
+        let dir_2 = fs.readdirSync(__dirname + "/../../../api");
+
+        for(let i = 0; i < dir_1.length; i++){
+            start_dirs.push(__dirname + "/../api/" + dir_1[i]);
+        }
+        for(let i = 0; i < dir_2.length; i++){
+            start_dirs.push(__dirname + "/../../../api/" + dir_2[i]);
+        }
+
+        let js_files = [];
+
+        let recursive_read = function(dir){
+            let dirs = fs.readdirSync(dir);
+            for(let i = 0; i < dirs.length; i++){
+                let ndir = dir + "/" + dirs[i];
+                if(fs.lstatSync(ndir).isDirectory()){
+                    recursive_read(ndir);
+                }else if(fs.lstatSync(ndir).isFile() && ndir.endsWith(".js")) {
+                    js_files.push(ndir);
+                }
+            }
+        }
+
+        for(let i = 0; i < start_dirs.length; i++){
+            let dir = start_dirs[i];
+            if(fs.lstatSync(dir).isDirectory()){
+                recursive_read(dir);
+            }else if(fs.lstatSync(dir).isFile() && dir.endsWith(".js")){
+                js_files.push(dir);
+            }
+        }
+
+        const exclude_list = [
+            __dirname + "/../api/APIUtil.js",
+            __dirname + "/../api/index.js",
+            __dirname + "/../api/SanctumUtil.js",
+            __dirname + "/../api/sanitizer.js",
+            __dirname + "/../api/ServerException.js",
+            __dirname + "/../api/StaticUtil.js"
+        ]
+
+        let permissions = [];
+
+        for(let i = 0; i < js_files.length; i++){
+            let js_file = js_files[i];
+            if(!exclude_list.includes(js_file)){
+                let data = fs.readFileSync(js_file, {encoding:'utf8', flag:'r'});
+                let match_result = data.match(/APIUtil.hasPermission\(.+,.*("|')(.*)("|')/);
+                if(match_result !== null && match_result.length > 3){
+                    let permission = match_result[2];
+                    if(!permissions.includes(permission)){
+                        permissions.push(permission);
+                    }
+                }
+            }
+        }
+
+        return permissions;
+    }
+
+    loadFrontendPermissions(){
+        const search_dirs = [
+            __dirname + "/../pages",
+            __dirname + "/../layouts",
+            __dirname + "/../../../pages",
+            __dirname + "/../../../components"
+        ];
+
+        if(fs.existsSync(__dirname + "/../../aspect")){
+            search_dirs.push(__dirname + "/../../aspect/components");
+            search_dirs.push(__dirname + "/../../aspect/layouts");
+        }
+
+        let vue_files = [];
+
+        let recursive_read = function(dir){
+            let dirs = fs.readdirSync(dir);
+            for(let i = 0; i < dirs.length; i++){
+                let ndir = dir + "/" + dirs[i];
+                if(fs.lstatSync(ndir).isDirectory()){
+                    recursive_read(ndir);
+                }else if(fs.lstatSync(ndir).isFile() && ndir.endsWith(".vue")) {
+                    vue_files.push(ndir);
+                }
+            }
+        }
+
+        for(let i = 0; i < search_dirs.length; i++){
+            let dir = search_dirs[i];
+            if(fs.lstatSync(dir).isDirectory()){
+                recursive_read(dir);
+            }else if(fs.lstatSync(dir).isFile() && dir.endsWith(".vue")){
+                vue_files.push(dir);
+            }
+        }
+
+        let permissions = [];
+
+        for(let i = 0; i < vue_files.length; i++){
+            let vue_file = vue_files[i];
+            let data = fs.readFileSync(vue_file, {encoding:'utf8', flag:'r'});
+            let match_result = data.match(/\$store.getters\['boost_store\/hasPermission'\]\(("|')(.*)("|')\)/);
+            if(match_result !== null && match_result.length > 3){
+                let permission = match_result[2];
+                if(!permissions.includes(permission)){
+                    permissions.push(permission);
+                }
+            }
+        }
+
+        return permissions;
+    }
+
+}
+
+module.exports = PermissionLoaderPlugin;

--- a/server.config.js
+++ b/server.config.js
@@ -14,7 +14,7 @@ module.exports = {
         location: 'https://sanctum.epicdev.co.za',
         project_key: ''
     },
-    plugins: [],
+    plugins: [__dirname + "/plugins/PermissionLoaderPlugin"],
     endpoints: {
         'auth': {
             children: {

--- a/store/boost_store.js
+++ b/store/boost_store.js
@@ -27,8 +27,6 @@ export default (() => {
             hasPermission: (state) => (permission_node) => {
                 let node_array = (Array.isArray(permission_node)) ? permission_node : [permission_node];
 
-                let granted = true;
-
                 if(state.superuser){
                     return true;
                 }
@@ -39,12 +37,33 @@ export default (() => {
 
                 for(let i = 0; i < node_array.length; i++){
                     let permission = node_array[i];
-                    if(!state.permissions.includes(permission)){
-                        granted = false;
+
+                    let split_permission = permission.split('.');
+
+                    for(let x = 0; x < state.permissions.length; x++){
+                        let granted_permission = state.permissions[x].split(".");
+                        let passed_count = 0;
+                        for(let i = 0; i < split_permission.length; i++){
+                            if(granted_permission.length >= i+1){
+                                let granted_node = granted_permission[i];
+                                let needed_node = split_permission[i];
+                                if(granted_node !== needed_node){
+                                    if(granted_node === "*" && passed_count === i){
+                                        return true;
+                                    }
+                                }else{
+                                    passed_count++;
+                                }
+                            }
+                        }
+
+                        if(passed_count === split_permission.length){
+                            return true;
+                        }
                     }
                 }
 
-                return granted;
+                return false;
             }
         }
     };


### PR DESCRIPTION
Usernames are now enforced to be email addresses
Turned login screen into a component with multiple slots to allow easy overriding of certain sections
Added scraping of front-end permission usage on application start to add to the permission auto fill list.
Added support for permission wildcards using the .* notation. Example:
- project.module.*
- project.*
- project.module.feature.*
- *